### PR TITLE
Allow to not show the toolbar with Done button

### DIFF
--- a/Sources/CITPincode/CITPincodeView+Configuration.swift
+++ b/Sources/CITPincode/CITPincodeView+Configuration.swift
@@ -72,7 +72,10 @@ extension CITPincodeView {
         
         /// If set to true, the keyboard will show once the pincode view appears.
         public var showKeyboardOnAppear: Bool
-        
+
+        /// If set to true, the toolbar with a button that can close the keyboard will be shown.
+        public var showKeyboardDoneButton: Bool
+
         /// Text shown for the button that can close the keyboard from a toolbar.
         public var keyboardDoneButtonText: String
         
@@ -142,6 +145,7 @@ extension CITPincodeView {
             selectedBorderWidth: CGFloat                        = 1,
             alwaysShowSelectedBorder: Bool                      = false,
             showKeyboardOnAppear: Bool                          = true,
+            showKeyboardDoneButton: Bool                        = true,
             keyboardDoneButtonText: String                      = "citpincode_keyboard_done_button_text".localized,
             cellSize: CGSize                                    = .init(width: 40, height: 56),
             cellCornerRadius: CGFloat                           = 8,
@@ -163,6 +167,7 @@ extension CITPincodeView {
             self.selectedBorderWidth = selectedBorderWidth
             self.alwaysShowSelectedBorder = alwaysShowSelectedBorder
             self.showKeyboardOnAppear = showKeyboardOnAppear
+            self.showKeyboardDoneButton = showKeyboardDoneButton
             self.keyboardDoneButtonText = keyboardDoneButtonText
             self.cellSize = cellSize
             self.cellCornerRadius = cellCornerRadius

--- a/Sources/CITPincode/CITPincodeView.swift
+++ b/Sources/CITPincode/CITPincodeView.swift
@@ -1,6 +1,6 @@
 //
 //  CITPincodeView.swift
-//  
+//
 //  MIT License
 //
 //  Copyright (c) 2022 Coffee IT
@@ -137,7 +137,9 @@ public struct CITPincodeView: View {
     private func setupPasteOnlyTextField(_ textField: UITextField) {
         DispatchQueue.main.async {
             codeInputField = textField
-            textField.addDoneButton(config.keyboardDoneButtonText)
+            if config.showKeyboardDoneButton {
+                textField.addDoneButton(config.keyboardDoneButtonText)
+            }
             showKeyboardInitially()
         }
     }


### PR DESCRIPTION
Sometimes the toolbar with "Done" button is not needed and it's preferable to not dismiss the keyboard at all.

This PR introduces `Configuration.showKeyboardDoneButton` property to resolve the issue.